### PR TITLE
Sorting events - DESC occurred at

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -88,7 +88,7 @@ module LoginGov::IdpAttemptsTracker
       end
 
       erb :index, locals: {
-        events: decrypted_events&.sort_by { |e| e["iat"] },
+        events: decrypted_events&.sort_by { |e| -e["iat"] },
         response_status: response_status,
         response_error: response_error,
       }

--- a/app.rb
+++ b/app.rb
@@ -88,7 +88,7 @@ module LoginGov::IdpAttemptsTracker
       end
 
       erb :index, locals: {
-        events: decrypted_events&.sort_by { |e| -e["iat"] },
+        events: decrypted_events&.sort_by { |e| e["iat"] }&.reverse,
         response_status: response_status,
         response_error: response_error,
       }


### PR DESCRIPTION
Sorting an events list by desc occurred_at to show the latest event at the top.